### PR TITLE
update build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 cli for orchestrating software development environments
 
-| master | dev |
+| build | release |
 | :----: | :-: |
-| [![Build Status](https://travis-ci.org/edgetools/mise.svg?branch=master)](https://travis-ci.org/edgetools/mise) | [![Build Status](https://travis-ci.org/edgetools/mise.svg?branch=dev)](https://travis-ci.org/edgetools/mise)
+| [![build](https://img.shields.io/travis/edgetools/mise/master.svg?branch=master)](https://travis-ci.org/edgetools/mise) | [![downloads](https://img.shields.io/powershellgallery/dt/mise.svg?label=downloads)](https://www.powershellgallery.com/packages/mise)
+
+
+


### PR DESCRIPTION
now that we're on a single CI branch, with PRs, this changes the build badge to just display master, and adds a downloads link for the powershellgallery page